### PR TITLE
fix bug radar.py

### DIFF
--- a/lib/controller/python/controller/radar.py
+++ b/lib/controller/python/controller/radar.py
@@ -51,7 +51,7 @@ class Radar(Sensor):
         data = wb.wb_radar_get_targets(self._tag)
         list = []
         for i in range(number_of_targets):
-            list.append(RadarTarget(data[0], data[1], data[2], data[3]))
+            list.append(RadarTarget(data[0 + 4*i], data[1 + 4*i], data[2 + 4*i], data[3 + 4*i]))
         return list
 
     @property


### PR DESCRIPTION
Fixed the bug that when using Python to write a controller, using getTargets() could not correctly obtain multiple target data detected by radar
**Describe the Bug**
Use the Python controller to call getTargets() to obtain the data list of the four targets detected by the radar sensor. The data of the four targets are the same. After repeated tests, it is found that the data of the four targets are all obtained from the first target, instead of  the data of the four targets as I expected.

**Steps to Reproduce**
1. Robot is equipped with a radar sensor
2. Running the simulation, the radar detects multiple targets.
3. In the Python controller, use getTargets() to get a list of data for the four targets.

**Expected behavior**
Get data on multiple detected targets


**System**
 - Operating System: Windows 10 or  Linux Ubuntu 22.04

